### PR TITLE
Use external kextsymboltool if building on Linux

### DIFF
--- a/SETUP/Makefile
+++ b/SETUP/Makefile
@@ -14,8 +14,6 @@ SETUP_SUBDIRS = 	\
 
 ifeq ($(UNAME_S),Darwin)
 	SETUP_SUBDIRS += kextsymboltool
-endif
-ifneq ($(UNAME_S),Linux)
 	SETUP_SUBDIRS += setsegname
 endif
 

--- a/makedefs/MakeInc.cmd
+++ b/makedefs/MakeInc.cmd
@@ -119,10 +119,11 @@ endif
 # Scripts or tools we build ourselves
 ifneq ($(UNAME_S),Linux)
 	SEG_HACK := $(OBJROOT)/SETUP/setsegname/setsegname
+	KEXT_CREATE_SYMBOL_SET := $(OBJROOT)/SETUP/kextsymboltool/kextsymboltool
 else
 	SEG_HACK := /usr/bin/setsegname
+	KEXT_CREATE_SYMBOL_SET := /usr/bin/kextsymboltool
 endif
-KEXT_CREATE_SYMBOL_SET := $(OBJROOT)/SETUP/kextsymboltool/kextsymboltool
 DECOMMENT := $(OBJROOT)/SETUP/decomment/decomment
 NEWVERS = $(SRCROOT)/config/newvers.pl
 MD := $(OBJROOT)/SETUP/md/md


### PR DESCRIPTION
- When building on Linux hosts, use external kextsymboltool provided by xnu-deps-linux.
