### PR TITLE
Fix register read over KDP

### DIFF
--- a/osfmk/arm/trap.c
+++ b/osfmk/arm/trap.c
@@ -250,7 +250,7 @@ void sleh_abort(void *context, int reason)
                 if (code != KERN_SUCCESS) {
 
                     if (current_debugger) {
-                        if (kdp_raise_exception(EXC_BREAKPOINT, 0, 0, &arm_ctx))
+                        if (kdp_raise_exception(EXC_BREAKPOINT, 0, 0, arm_ctx))
                             return;
                     }
 


### PR DESCRIPTION
KDP was broken due to improperly passing a pointer to the register state struct by reference from sleh_abort() to kdp_raise_exception()